### PR TITLE
Fix Umbrel detection and make it work with 0.5.0

### DIFF
--- a/igniter.sh
+++ b/igniter.sh
@@ -17,8 +17,14 @@ IFS=, eval 'HOPS="${pub_keys[*]}"'
 
 # If an umbrel, use docker, else call lncli directly. Also setup dependencies accordingly.
 LNCLI="lncli"
-if uname -a | grep umbrel > /dev/null; then
-    LNCLI="docker exec -i lnd lncli"
+if [ -d "$HOME/umbrel" ] ; then
+    # Umbrel < 0.5.x
+    if [ "docker ps -q  -f name=^lnd$" ] ; then
+      LNCLI="docker exec -i lnd lncli"
+    # Umbrel >= 0.5.x
+    else
+      LNCLI="$HOME/umbrel/scripts/app compose lightning exec lnd lncli"
+    fi
     dependencies="cat jq"
 else
     dependencies="cat jq lncli"


### PR DESCRIPTION
This PR changes the Umbrel detection to make it work with non-RPi installs.
Also adds support for the new Umbrel directory layout introduced in 0.5.0, while still supporting the pre-0.5.0 way they did things. 