### PR TITLE
Improvment for umbrel installs in custom directories

### DIFF
--- a/igniter.sh
+++ b/igniter.sh
@@ -17,17 +17,20 @@ IFS=, eval 'HOPS="${pub_keys[*]}"'
 
 # If an umbrel, use docker, else call lncli directly. Also setup dependencies accordingly.
 LNCLI="lncli"
-if [ -d "$HOME/umbrel" ] ; then
-    # Umbrel < 0.5.x
-    if docker ps -q  -f name=^lnd$ | grep -q . ; then
-      LNCLI="docker exec -i lnd lncli"
-    # Umbrel >= 0.5.x
-    else
-      LNCLI="$HOME/umbrel/scripts/app compose lightning exec lnd lncli"
+dependencies="cat jq lncli"
+
+# Check if docker is installed
+if command -v docker &> /dev/null; then
+    CONTAINERS=$(docker ps --format "{{.Names}}")
+
+    # Check if the container is running
+    if grep -qw "lightning_lnd_1" <<< "$CONTAINERS"; then
+        # Umbrel 
+        LNCLI="docker exec -i lightning_lnd_1 lncli"
+        dependencies="cat jq"
     fi
-    dependencies="cat jq"
 else
-    dependencies="cat jq lncli"
+    echo "Docker is not installed"
 fi
 
 # Arg option: 'build'


### PR DESCRIPTION
If user has Umbrel in a customer directory, the script will fail. Not a frequent occurence but this is an option in the Umbrel install script.

One workaround would be to:
1. Check if docker is installed.
2. Check if container named lightning_lnd_1 is running since this is a "signature" Umbrel container name for lnd.
3. Run lncli with `docker exec -i lightning_lnd_1 lncli` instead

This also nulls the need to do a version check. The lnd container name has remained the same since inception.